### PR TITLE
Upgrade Django to 1.10.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pytest==3.0.3
 pytest-cov==2.4.0
 pytest-django==3.0.0
 flake8==3.0.4
-django==1.10.3
+django==1.10.7
 djangorestframework==3.5.3
 


### PR DESCRIPTION
### Proposed changes in this pull request

Upgrades Django to 1.10.7 for #26. Includes two security fixes and some bug fixes.

Release notes: https://docs.djangoproject.com/en/dev/releases/1.10.7/

### When should this PR be merged

ASAP

### Risks

Low; minor fixes included