### PR TITLE
Allow view_kwargs argument for APITestCase.request

### DIFF
--- a/skivvy/__init__.py
+++ b/skivvy/__init__.py
@@ -219,7 +219,7 @@ class APITestCase(ViewTestCase):
 
     def request(self, method='GET', user=AnonymousUser(), url_kwargs={},
                 post_data={}, get_data={}, content_type='application/json',
-                request_meta={}):
+                request_meta={}, view_kwargs={}):
         kwargs = locals()
         del kwargs['self']
         self._request, response = self._make_request(

--- a/skivvy/__init__.py
+++ b/skivvy/__init__.py
@@ -13,7 +13,7 @@ from django.test import RequestFactory
 from django.conf import settings
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 Response = namedtuple('Response',
                       'status_code content location messages headers')

--- a/tests/test_api_case.py
+++ b/tests/test_api_case.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock
 from django.test import TestCase
 from django.contrib.auth.models import User
 from skivvy import APITestCase
@@ -136,3 +137,18 @@ def test_request_viewset_actions():
     assert 'content-type' in response.headers
     assert response.headers['content-type'][1] == 'application/json'
     assert len(response.messages) == 0
+
+
+def test_request_overwrite_view_kwargs():
+    # default view_kwargs are {'test_arg': False}; by overwriting view_kwargs
+    # in request(), setup_view should be called with
+    # view_kwargs={'test_arg': True}
+
+    class TheCase(APITestCase, TestCase):
+        view_class = APITestView
+
+    case = TheCase()
+    case.setup_view = MagicMock()
+    case.request(view_kwargs={'test_arg': True})
+
+    case.setup_view.assert_called_with(view_kwargs={'test_arg': True})

--- a/tests/views.py
+++ b/tests/views.py
@@ -39,6 +39,8 @@ class GenericRedirectView(View):
 
 
 class APITestView(APIView):
+    test_arg = False
+
     def get(self, request, *args, **kwargs):
         return Response({"some": "json"})
 


### PR DESCRIPTION
Allows `view_kwargs` argument for `APITestCase.request`, which allows overwriting default arguments passed to the test view. 