### PR TITLE
Fix encoding of non-string POST values

### DIFF
--- a/skivvy/__init__.py
+++ b/skivvy/__init__.py
@@ -14,7 +14,7 @@ from django.test import RequestFactory
 from django.conf import settings
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-__version__ = '0.1.7'
+__version__ = '0.1.8'
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 Response = namedtuple('Response',
                       'status_code content location messages headers')
@@ -203,7 +203,7 @@ class ViewTestCase:
 
     @staticmethod
     def _url_encode_data(data):
-        return '&'.join(['{}={}'.format(k, parse.quote_plus(v))
+        return '&'.join(['{}={}'.format(k, parse.quote_plus(str(v)))
                         for k, v in data.items()])
 
 

--- a/tests/test_api_case.py
+++ b/tests/test_api_case.py
@@ -12,7 +12,6 @@ def test_get_post_data_multipart():
 
     case = TheCase()
     post_data = case._get_post_data(content_type='multipart/form-data')
-    print(post_data)
     assert (post_data.decode() == '--BoUnDaRyStRiNg\r\nContent-Disposition: '
                                   'form-data; name="some"\r\n\r\ndata\r\n--'
                                   'BoUnDaRyStRiNg--\r\n')

--- a/tests/test_view_case.py
+++ b/tests/test_view_case.py
@@ -480,6 +480,44 @@ def test_request_post():
     assert len(response.messages) == 0
 
 
+def test_request_post_with_number():
+    class TheCase(ViewTestCase, TestCase):
+        view_class = views.GenericView
+        post_data = {'data': 1}
+
+    user = User(username='user')
+    case = TheCase()
+    response = case.request(user=user, method='POST')
+
+    assert case._request.user == user
+    assert case._request.method == 'POST'
+
+    assert response.status_code == 200
+    assert response.content == '<h1>data: 1<h1>'
+    assert response.location is None
+    assert 'content-type' in response.headers
+    assert len(response.messages) == 0
+
+
+def test_request_post_with_bool():
+    class TheCase(ViewTestCase, TestCase):
+        view_class = views.GenericView
+        post_data = {'data': True}
+
+    user = User(username='user')
+    case = TheCase()
+    response = case.request(user=user, method='POST')
+
+    assert case._request.user == user
+    assert case._request.method == 'POST'
+
+    assert response.status_code == 200
+    assert response.content == '<h1>data: True<h1>'
+    assert response.location is None
+    assert 'content-type' in response.headers
+    assert len(response.messages) == 0
+
+
 def test_render_csrf_token():
     class TheCase(ViewTestCase, TestCase):
         view_class = views.CsrfTemplateView


### PR DESCRIPTION
Since PR #32 was merged, posting non-string values raises a `TypeError` for because `quote_from_bytes`, which is called from `urllib.parse.quote_plus`, expects a value of type `bytes` or `bytesarray`. 

This is fixed by converting all values in `_url_encode_data` to `string` before passing them to `quote_plus`. 

Also, bumps the current version to 0.1.8.