### PR TITLE
Allow data storage in request sessions

### DIFF
--- a/skivvy/__init__.py
+++ b/skivvy/__init__.py
@@ -35,7 +35,8 @@ class ViewTestCase:
             self.setup_models()
 
     def request(self, method='GET', user=AnonymousUser(), url_kwargs={},
-                post_data={}, get_data={}, view_kwargs={}, request_meta={}):
+                post_data={}, get_data={}, view_kwargs={}, request_meta={},
+                session_data={}):
         kwargs = locals()
         del kwargs['self']
         self._request, response = self._make_request(**kwargs)
@@ -59,7 +60,8 @@ class ViewTestCase:
     def _make_request(self, method='GET', user=AnonymousUser(), url_kwargs={},
                       get_data={}, post_data={}, request_meta={},
                       view_kwargs={}, auth_func=None,
-                      content_type='application/x-www-form-urlencoded'):
+                      content_type='application/x-www-form-urlencoded',
+                      session_data={}):
         self.content_type = content_type
         url_params = self._get_url_params(get_data)
         url = '/?' + url_params if url_params else '/'
@@ -76,6 +78,8 @@ class ViewTestCase:
             setattr(request, 'session', SessionStore())
             self.messages = FallbackStorage(request)
             setattr(request, '_messages', self.messages)
+            for k, v in session_data.items():
+                request.session[k] = v
 
         if auth_func:
             auth_func(request, user)

--- a/tests/test_view_case.py
+++ b/tests/test_view_case.py
@@ -530,19 +530,19 @@ def test_render_csrf_token():
     assert response.content == case.expected_content
 
 
-def test_request_post_with_session_data():
+def test_request_get_with_session_data():
     class TheCase(ViewTestCase, TestCase):
         view_class = views.GenericView
-        post_data = {'data': 'abc def :?!@.?'}
 
     case = TheCase()
     session_data = {'s_data': 'Session Data'}
-    response = case.request(method='POST', session_data=session_data)
-    assert case._request.method == 'POST'
+    response = case.request(method='GET', session_data=session_data)
+    assert case._request.method == 'GET'
     assert case._request.session['s_data'] == 'Session Data'
 
     assert response.status_code == 200
-    assert response.content == '<h1>data: abc def :?!@.?<h1>Session Data'
+    assert response.content == '<h1>Test content<h1><p>Session Data</p>'
     assert response.location is None
     assert 'content-type' in response.headers
-    assert len(response.messages) == 0
+    assert len(response.messages) == 1
+    assert 'Hello world.' in response.messages

--- a/tests/test_view_case.py
+++ b/tests/test_view_case.py
@@ -528,3 +528,21 @@ def test_render_csrf_token():
 
     assert response.status_code == 200
     assert response.content == case.expected_content
+
+
+def test_request_post_with_session_data():
+    class TheCase(ViewTestCase, TestCase):
+        view_class = views.GenericView
+        post_data = {'data': 'abc def :?!@.?'}
+
+    case = TheCase()
+    session_data = {'s_data': 'Session Data'}
+    response = case.request(method='POST', session_data=session_data)
+    assert case._request.method == 'POST'
+    assert case._request.session['s_data'] == 'Session Data'
+
+    assert response.status_code == 200
+    assert response.content == '<h1>data: abc def :?!@.?<h1>Session Data'
+    assert response.location is None
+    assert 'content-type' in response.headers
+    assert len(response.messages) == 0

--- a/tests/views.py
+++ b/tests/views.py
@@ -16,8 +16,12 @@ class GenericView(View):
         return HttpResponse('<h1>Test content<h1>')
 
     def post(self, request, *args, **kwargs):
+        s_data = self.request.session.get('s_data')
         field, value = dict(request.POST).popitem()
-        return HttpResponse('<h1>{}: {}<h1>'.format(field, value[0]))
+        data = '<h1>{}: {}<h1>'.format(field, value[0])
+        if s_data:
+            data = data + s_data
+        return HttpResponse(data)
 
 
 class GenericTemplateView(TemplateView):

--- a/tests/views.py
+++ b/tests/views.py
@@ -13,15 +13,15 @@ class GenericView(View):
 
     def get(self, request, *args, **kwargs):
         messages.add_message(request, messages.INFO, 'Hello world.')
-        return HttpResponse('<h1>Test content<h1>')
+        s_data = self.request.session.get('s_data')
+        data = '<h1>Test content<h1>'
+        if s_data:
+            data = data + '<p>{}</p>'.format(s_data)
+        return HttpResponse(data)
 
     def post(self, request, *args, **kwargs):
-        s_data = self.request.session.get('s_data')
         field, value = dict(request.POST).popitem()
-        data = '<h1>{}: {}<h1>'.format(field, value[0])
-        if s_data:
-            data = data + s_data
-        return HttpResponse(data)
+        return HttpResponse('<h1>{}: {}<h1>'.format(field, value[0]))
 
 
 class GenericTemplateView(TemplateView):


### PR DESCRIPTION
Currently, Django-skivvy doesn't allow to pass data that needs to be stored in the session, which is required in some cases. With this PR, any data that needs to be stored in the session can be passed via `session_data` parameter in the request. This data must be passed as a dictionary key-value pair.

Changes:
1. Add `session_data` parameter to  `ViewTestCase.request()` and `ViewTestCase._make_request()`.
`session_data` accepts a dictionary value. The key-value pairs passed to `session_data` will be stored in request.session.
2. Make change to `GenericView` in `tests/views.py`. Add `s_data` variable that expects a value from request.session.
Add a `test_request_post_with_session_data` test to 'tests/test_view_case.py` for the same change.

Example:
```
In [15]: view = ConfirmPhoneViewTest()
In [16]: view.setup_models()
In [17]: data = {'token': '964858'}
In [18]: session_data = {'user_id':view.user.id}
In [19]: response = view.request(method='POST',post_data=data,session_data=session_data)
In [20]: response
Out[20]: Response(status_code=302, content='', location='/account/login/', messages=['Successfully verified +1234567891'], headers={'location': ('Location', '/account/login/'), 'content-type': ('Content-Type', 'text/html; charset=utf-8')})
```