### PR TITLE
Documentation update

### DIFF
--- a/docs/content/setup.md
+++ b/docs/content/setup.md
@@ -24,7 +24,7 @@ class MyViewTestCase(APITestCase, TestCase):
 
 ### Getting a response
 
-The method `request` returns a response from your view. The response returned is based on the generic [ configuration](#test-configuration) of the test case. 
+The method `request` returns a response from your view. The response returned is based on the generic [configuration](#test-configuration) of the test case. 
 
 To test special cases, you can use `url_kwargs`, `get_data`, `post_data`, `session_data`, `view_kwargs` and `content_type` parameters to temporarily overwrite the generic test setup. 
 
@@ -43,12 +43,12 @@ class MyViewTestCase(ViewTestCase, TestCase):
 | Argument      | Type          | Default       | Description   |
 | ------------- | ------------- | ------------- | ------------- |
 | `method`      | `str`         | `GET`         | HTTP method used for the request|
-| `user`        | [`User`](https://docs.djangoproject.com/en/1.9/ref/contrib/auth/#user-model)   | [`AnonymousUser`](https://docs.djangoproject.com/en/1.9/ref/contrib/auth/#django.contrib.auth.models.AnonymousUser) | User authticated with this request. |
+| `user`        | [`User`](https://docs.djangoproject.com/en/1.9/ref/contrib/auth/#user-model)   | [`AnonymousUser`](https://docs.djangoproject.com/en/1.9/ref/contrib/auth/#django.contrib.auth.models.AnonymousUser) | User authenticated with this request. |
 | `url_kwargs`  | `dict`        | `{}`          | URL arguments passed to the view.  `ViewTestCase` applies this dictionary to what is defined in `url_kwargs` or `get_url_kwargs`. |
 | `get_data`   | `dict`        | `{}`          | Adds query parameters to the request URL. E.g., to test a request to `/some/path/?filter=foo` add `get_data={'filter': 'foo'}`. |
 | `post_data`   | `dict`        | `{}`          | Request payload, only relevant for `POST`, `PUT` and `PATCH` requests. `ViewTestCase` applies this dictionary to what is defined in `post_data` or `setup_post_data`. Partial overwrites are allowed. |
 | `session_data`   | `dict`        | `{}`          | If your view relies on data from the session store, you can provide this data using `session_data`. |
-| `view_kargs`   | `dict`        | `{}`          | Overwrites attibutes set in the view class. The behaviour corrspenponds to [providing keyword arguments to a class-based view's `as_view()` method](https://docs.djangoproject.com/en/1.11/topics/class-based-views/#simple-usage-in-your-urlconf).  |
+| `view_kwargs`   | `dict`        | `{}`          | Overwrites attributes set in the view class. The behaviour corresponds to [providing keyword arguments to a class-based view's `as_view()` method](https://docs.djangoproject.com/en/1.11/topics/class-based-views/#simple-usage-in-your-urlconf).  |
 | `content_type`   | `str`        | `application/json`          | **Only available for `APITestCase`**. Sets the content type encoding for the request. |
 
 ### Evaluating a response

--- a/docs/content/setup.md
+++ b/docs/content/setup.md
@@ -26,7 +26,7 @@ class MyViewTestCase(APITestCase, TestCase):
 
 The method `request` returns a response from your view. The response returned is based on the generic [ configuration](#test-configuration) of the test case. 
 
-To test special cases, you can use `url_kwargs`, `get_data`, `post_data`, `session_data` and `content_type` parameters to temporarily overwrite the generic test setup. 
+To test special cases, you can use `url_kwargs`, `get_data`, `post_data`, `session_data`, `view_kwargs` and `content_type` parameters to temporarily overwrite the generic test setup. 
 
 ```python
 class MyViewTestCase(ViewTestCase, TestCase):
@@ -36,7 +36,8 @@ class MyViewTestCase(ViewTestCase, TestCase):
                                  url_kwargs={},
                                  get_data={},
                                  post_data={},
-                                 session_data={})
+                                 session_data={},
+                                 view_kwargs={})
 ```
 
 | Argument      | Type          | Default       | Description   |
@@ -47,6 +48,7 @@ class MyViewTestCase(ViewTestCase, TestCase):
 | `get_data`   | `dict`        | `{}`          | Adds query parameters to the request URL. E.g., to test a request to `/some/path/?filter=foo` add `get_data={'filter': 'foo'}`. |
 | `post_data`   | `dict`        | `{}`          | Request payload, only relevant for `POST`, `PUT` and `PATCH` requests. `ViewTestCase` applies this dictionary to what is defined in `post_data` or `setup_post_data`. Partial overwrites are allowed. |
 | `session_data`   | `dict`        | `{}`          | If your view relies on data from the session store, you can provide this data using `session_data`. |
+| `view_kargs`   | `dict`        | `{}`          | Overwrites attibutes set in the view class. The behaviour corrspenponds to [providing keyword arguments to a class-based view's `as_view()` method](https://docs.djangoproject.com/en/1.11/topics/class-based-views/#simple-usage-in-your-urlconf).  |
 | `content_type`   | `str`        | `application/json`          | **Only available for `APITestCase`**. Sets the content type encoding for the request. |
 
 ### Evaluating a response

--- a/docs/content/setup.md
+++ b/docs/content/setup.md
@@ -26,7 +26,7 @@ class MyViewTestCase(APITestCase, TestCase):
 
 The method `request` returns a response from your view. The response returned is based on the generic [ configuration](#test-configuration) of the test case. 
 
-To test special cases, you can use `url_kwargs`, `get_data` and `post_data` parameters to temporarily overwrite the generic test setup. 
+To test special cases, you can use `url_kwargs`, `get_data`, `post_data`, `session_data` and `content_type` parameters to temporarily overwrite the generic test setup. 
 
 ```python
 class MyViewTestCase(ViewTestCase, TestCase):
@@ -35,7 +35,8 @@ class MyViewTestCase(ViewTestCase, TestCase):
                                  user=AnonymousUser(),
                                  url_kwargs={},
                                  get_data={},
-                                 post_data={})
+                                 post_data={},
+                                 session_data={})
 ```
 
 | Argument      | Type          | Default       | Description   |
@@ -45,6 +46,7 @@ class MyViewTestCase(ViewTestCase, TestCase):
 | `url_kwargs`  | `dict`        | `{}`          | URL arguments passed to the view.  `ViewTestCase` applies this dictionary to what is defined in `url_kwargs` or `get_url_kwargs`. |
 | `get_data`   | `dict`        | `{}`          | Adds query parameters to the request URL. E.g., to test a request to `/some/path/?filter=foo` add `get_data={'filter': 'foo'}`. |
 | `post_data`   | `dict`        | `{}`          | Request payload, only relevant for `POST`, `PUT` and `PATCH` requests. `ViewTestCase` applies this dictionary to what is defined in `post_data` or `setup_post_data`. Partial overwrites are allowed. |
+| `session_data`   | `dict`        | `{}`          | If your view relies on data from the session store, you can provide this data using `session_data`. |
 | `content_type`   | `str`        | `application/json`          | **Only available for `APITestCase`**. Sets the content type encoding for the request. |
 
 ### Evaluating a response


### PR DESCRIPTION
- Resolves #30: Add documentation for `session_data` keyword argument for the `request` method.
- Resolves #40: Add documentation for `view_kwargs` keyword argument for the `request` method.