### PR TITLE
Removes Django 1.10 support; enables Django 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,17 @@ sudo: false
 python:
   - '3.5'
 env:
-  - TOXENV=py34-django110
-  - TOXENV=py35-django110
   - TOXENV=py34-django111
   - TOXENV=py35-django111
+  - TOXENV=py34-django20
+  - TOXENV=py35-django20
   - TOXENV=py35-flake8
 matrix:
   include:
     - python: "3.6"
       env: TOXENV=py36-django111
+    - python: "3.6"
+      env: TOXENV=py36-django20
 install:
   - pip install tox
 script:

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ django-skivvy helps you write better and more readable tests for Django views.
 Requirements
 ~~~~~~~~~~~~
 - Python 3.4, 3.5 or 3.6
-- Django 1.10 or 1.11
+- Django 1.11, 2.0
 
 
 Installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pytest==3.2.5
 pytest-cov==2.5.1
 pytest-django==3.1.2
 flake8==3.5.0
-django==1.11.7
+django==2.0
 djangorestframework==3.7.3
 

--- a/skivvy/__init__.py
+++ b/skivvy/__init__.py
@@ -7,12 +7,17 @@ from django.core.exceptions import ImproperlyConfigured
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.template.loader import render_to_string
-from django.core.urlresolvers import reverse
 from django.contrib.messages.api import get_messages
 from django.test.client import encode_multipart
 from django.test import RequestFactory
 from django.conf import settings
 from rest_framework.test import APIRequestFactory, force_authenticate
+try:
+    # For Django 1.11.x
+    from django.core.urlresolvers import reverse
+except ImportError:
+    # For Django 2.x
+    from django.urls import reverse
 
 __version__ = '0.1.9'
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{34,35}-django110,
     py{34,35,36}-django111,
+    py{34,35,36}-django20,
     py35-flake8
 
 [testenv]
@@ -16,8 +16,8 @@ deps =
     pytest-cov==2.5.1
     pytest-django==3.1.2
     flake8==3.5.0
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
+    django20: Django>=2.0,<2.1
     djangorestframework==3.7.3
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
Django 2.0 has been released and the lifetime of Django 1.10 has ended. This PR removes support for 1.10 and adds Django 2.0.

- Adds and removes the corresponding envs from the tox and travis scripts. 
- `django.core.urlresolvers` was removed with 2.0, so I added a try..catch block to support both versions. 